### PR TITLE
Add formatting for displaying measured heart rate value.

### DIFF
--- a/MeasureData/app/src/main/java/com/example/measuredata/MainActivity.kt
+++ b/MeasureData/app/src/main/java/com/example/measuredata/MainActivity.kt
@@ -76,7 +76,7 @@ class MainActivity : AppCompatActivity() {
         }
         lifecycleScope.launchWhenStarted {
             viewModel.heartRateBpm.collect {
-                binding.lastMeasuredValue.text = it.toString()
+		binding.lastMeasuredValue.text = String.format("%.1f", it)
             }
         }
     }


### PR DESCRIPTION
Format measure heart rate to be 2 decimal places.
Virtual heart rate sensor returns measured heart rate value as a float, which causes formatting errors. 