### PR TITLE
Adds onboarding URL to Play Store link

### DIFF
--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/data/HealthConnectManager.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/data/HealthConnectManager.kt
@@ -65,6 +65,10 @@ class HealthConnectManager(private val context: Context) {
         private set
 
     init {
+        checkAvailability()
+    }
+
+    fun checkAvailability() {
         availability.value = when {
             HealthConnectClient.isAvailable(context) -> HealthConnectAvailability.INSTALLED
             isSupported() -> HealthConnectAvailability.NOT_INSTALLED

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/component/NotInstalledMessage.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/component/NotInstalledMessage.kt
@@ -38,7 +38,13 @@ import com.example.healthconnectsample.presentation.theme.HealthConnectTheme
 @Composable
 fun NotInstalledMessage() {
     val tag = stringResource(R.string.not_installed_tag)
-    val url = stringResource(R.string.not_installed_url)
+    // Build the URL to allow the user to install the Health Connect package
+    val url = Uri.parse(stringResource(id = R.string.market_url))
+        .buildUpon()
+        .appendQueryParameter("id", stringResource(id = R.string.health_connect_package))
+        // Additional parameter to execute the onboarding flow.
+        .appendQueryParameter("url", stringResource(id = R.string.onboarding_url))
+        .build()
     val context = LocalContext.current
 
     val notInstalledText = stringResource(id = R.string.not_installed_description)
@@ -49,7 +55,7 @@ fun NotInstalledMessage() {
             append(notInstalledText)
             append("\n\n")
         }
-        pushStringAnnotation(tag = tag, annotation = url)
+        pushStringAnnotation(tag = tag, annotation = url.toString())
         withStyle(style = SpanStyle(color = MaterialTheme.colors.primary)) {
             append(notInstalledLinkText)
         }

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/navigation/HealthConnectNavigation.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/navigation/HealthConnectNavigation.kt
@@ -54,11 +54,14 @@ fun HealthConnectNavigation(
     scaffoldState: ScaffoldState
 ) {
     val scope = rememberCoroutineScope()
-    val availability by healthConnectManager.availability
     NavHost(navController = navController, startDestination = Screen.WelcomeScreen.route) {
+        val availability by healthConnectManager.availability
         composable(Screen.WelcomeScreen.route) {
             WelcomeScreen(
-                healthConnectAvailability = availability
+                healthConnectAvailability = availability,
+                onResumeAvailabilityCheck = {
+                    healthConnectManager.checkAvailability()
+                }
             )
         }
         composable(

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/WelcomeScreen.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/WelcomeScreen.kt
@@ -26,12 +26,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
 import com.example.healthconnectsample.R
 import com.example.healthconnectsample.data.HealthConnectAvailability
 import com.example.healthconnectsample.presentation.component.InstalledMessage
@@ -44,8 +51,33 @@ import com.example.healthconnectsample.presentation.theme.HealthConnectTheme
  */
 @Composable
 fun WelcomeScreen(
-    healthConnectAvailability: HealthConnectAvailability
+    healthConnectAvailability: HealthConnectAvailability,
+    onResumeAvailabilityCheck: () -> Unit,
+    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
 ) {
+    val currentOnAvailabilityCheck by rememberUpdatedState(onResumeAvailabilityCheck)
+
+    // Add a listener to re-check whether Health Connect has been installed each time the Welcome
+    // screen is resumed: This ensures that if the user has been redirected to the Play store and
+    // followed the onboarding flow, then when the app is resumed, instead of showing the message
+    // to ask the user to install Health Connect, the app recognises that Health Connect is now
+    // available and shows the appropriate welcome.
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                currentOnAvailabilityCheck()
+            }
+        }
+
+        // Add the observer to the lifecycle
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        // When the effect leaves the Composition, remove the observer
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -76,6 +108,9 @@ fun WelcomeScreen(
 @Composable
 fun NotInstalledMessagePreview() {
     HealthConnectTheme {
-        WelcomeScreen(healthConnectAvailability = HealthConnectAvailability.INSTALLED)
+        WelcomeScreen(
+            healthConnectAvailability = HealthConnectAvailability.INSTALLED,
+            onResumeAvailabilityCheck = {}
+        )
     }
 }

--- a/health-connect/HealthConnectSample/app/src/main/res/values/strings.xml
+++ b/health-connect/HealthConnectSample/app/src/main/res/values/strings.xml
@@ -40,7 +40,9 @@
 
     <!-- Not installed on device -->
     <string name="not_installed_tag">not_installed_tag</string>
-    <string name="not_installed_url">market://details?id=com.google.android.apps.healthdata</string>
+    <string name="market_url">market://details</string>
+    <string name="health_connect_package">com.google.android.apps.healthdata</string>
+    <string name="onboarding_url">"healthconnect://onboarding"</string>
     <string name="not_installed_description">
         Health Connect is supported on this device, but is not currently installed.
     </string>


### PR DESCRIPTION
- Adds onboarding URL to Play Store link for a smoother Health Connect install

When the user returns to the sample app from the Play Store onboarding experience, the app is able to determine that Health Connect is now installed and show the appropriate screen.