### PR TITLE
Fix formatting functions when values are NaN

### DIFF
--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/component/FormattingUtils.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/component/FormattingUtils.kt
@@ -59,7 +59,7 @@ fun formatElapsedTime(
 /** Format calories burned to an integer with a "cal" suffix. */
 @Composable
 fun formatCalories(calories: Double?) = buildAnnotatedString {
-    if (calories == null) {
+    if (calories == null || calories.isNaN()) {
         append("--")
     } else {
         append(calories.roundToInt().toString())
@@ -82,10 +82,10 @@ fun formatDistanceKm(meters: Double?) = buildAnnotatedString {
     }
 }
 
-/** Format heartrate with a "bpm" suffix. */
+/** Format heart rate with a "bpm" suffix. */
 @Composable
 fun formatHeartRate(bpm: Double?) = buildAnnotatedString {
-    if (bpm == null) {
+    if (bpm == null || bpm.isNaN()) {
         append("--")
     } else {
         append("%.0f".format(bpm))


### PR DESCRIPTION
### WHAT

Fix formatting functions when values are NaN:

![Screenshot_20230718_131053](https://github.com/android/health-samples/assets/878134/fc91f119-5432-49b4-8846-89016768a4dc)


### WHY

App is displaying "NaN" for AvgHR:

![Screenshot_20230718_131338](https://github.com/android/health-samples/assets/878134/7ebbf012-15cf-4305-9980-ca7ecdf08f0d)

App is crashing when scrolling down to calories:

```
2023-07-18 13:04:32.446  6622-6622  AndroidRuntime          com.example.exercisecompose          E  FATAL EXCEPTION: main
        Process: com.example.exercisecompose, PID: 6622
        java.lang.IllegalArgumentException: Cannot round NaN value.
        	at kotlin.math.MathKt__MathJVMKt.roundToInt(MathJVM.kt:619)
        	at com.example.exercisesamplecompose.presentation.component.FormattingUtilsKt.formatCalories(FormattingUtils.kt:65)
        	at com.example.exercisesamplecompose.presentation.summary.SummaryScreenKt$SummaryScreen$1$4.invoke(SummaryScreen.kt:96)
```
 