### PR TITLE
Add `android.permission.RECEIVE_BOOT_COMPLETED` to PassiveDataCompose

### DIFF
--- a/health-services/PassiveDataCompose/app/src/main/AndroidManifest.xml
+++ b/health-services/PassiveDataCompose/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
 
     <!-- Required for HR sensor -->
     <uses-permission android:name="android.permission.BODY_SENSORS" />
+    <!-- Needed in order to re-register for data on device startup. -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />    
 
     <uses-feature
         android:name="android.hardware.type.watch"


### PR DESCRIPTION
Looking at https://github.com/android/health-samples/blob/962247ccd2a00465e221f2a258c979a7c393b975/health-services/PassiveData/app/src/main/AndroidManifest.xml#L27C36-L27C77 and the docs here: https://developer.android.com/health-and-fitness/guides/health-services/monitor-background, it seems like this permission is missing