### PR TITLE
Fix crash by adding dependency

### DIFF
--- a/health-services/MeasureData/app/build.gradle
+++ b/health-services/MeasureData/app/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.core:core-ktx:1.13.1'
     implementation "androidx.fragment:fragment-ktx:1.7.1"
+    implementation 'androidx.work:work-runtime:2.9.0'
 
     // Hilt dependency injection
     implementation "com.google.dagger:hilt-android:$hilt_version"


### PR DESCRIPTION
Fix crash:
`Process: com.example.measuredata, PID: 6829
                                                                                                    java.lang.IllegalArgumentException: com.example.measuredata: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
                                                                                                    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.`