### PR TITLE
Remove series records from Exercise detail screen; add new Records screen

### DIFF
--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/data/ExerciseSessionData.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/data/ExerciseSessionData.kt
@@ -15,13 +15,9 @@
  */
 package com.example.healthconnectsample.data
 
-import androidx.health.connect.client.records.HeartRateRecord
-import androidx.health.connect.client.records.SpeedRecord
 import androidx.health.connect.client.units.Energy
 import androidx.health.connect.client.units.Length
-import androidx.health.connect.client.units.Velocity
 import java.time.Duration
-import java.time.Instant
 
 /**
  * Represents data, both aggregated and raw, associated with a single exercise session. Used to

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/data/ExerciseSessionData.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/data/ExerciseSessionData.kt
@@ -21,6 +21,7 @@ import androidx.health.connect.client.units.Energy
 import androidx.health.connect.client.units.Length
 import androidx.health.connect.client.units.Velocity
 import java.time.Duration
+import java.time.Instant
 
 /**
  * Represents data, both aggregated and raw, associated with a single exercise session. Used to
@@ -35,9 +36,4 @@ data class ExerciseSessionData(
     val minHeartRate: Long? = null,
     val maxHeartRate: Long? = null,
     val avgHeartRate: Long? = null,
-    val heartRateSeries: List<HeartRateRecord> = listOf(),
-    val minSpeed: Velocity? = null,
-    val maxSpeed: Velocity? = null,
-    val avgSpeed: Velocity? = null,
-    val speedRecord: List<SpeedRecord> = listOf()
 )

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/component/ExerciseSessionDetailsMinMaxAvg.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/component/ExerciseSessionDetailsMinMaxAvg.kt
@@ -35,9 +35,7 @@ fun ExerciseSessionDetailsMinMaxAvg(
     maximum: String?,
     average: String?
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth()
-    ) {
+    Row {
         Text(
             modifier = Modifier
                 .weight(1f),

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/component/ExerciseSessionDetailsMinMaxAvg.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/component/ExerciseSessionDetailsMinMaxAvg.kt
@@ -16,7 +16,6 @@
 package com.example.healthconnectsample.presentation.component
 
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/component/ExerciseSessionRow.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/component/ExerciseSessionRow.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -71,6 +72,11 @@ fun ExerciseSessionRow(
             onClick = { onDeleteClick(uid) },
         ) {
             Icon(Icons.Default.Delete, stringResource(R.string.delete_button))
+        }
+        IconButton(
+            onClick = { onDetailsClick(uid) },
+        ) {
+            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, stringResource(R.string.details_button))
         }
     }
 }

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/navigation/Screen.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/navigation/Screen.kt
@@ -18,6 +18,8 @@ package com.example.healthconnectsample.presentation.navigation
 import com.example.healthconnectsample.R
 
 const val UID_NAV_ARGUMENT = "uid"
+const val RECORD_TYPE = "recordType"
+const val SERIES_RECORDS_TYPE = "seriesRecordsType"
 
 /**
  * Represent all Screens in the app.
@@ -36,5 +38,6 @@ enum class Screen(val route: String, val titleId: Int, val hasMenuItem: Boolean 
     InputReadings("input_readings", R.string.input_readings),
     DifferentialChanges("differential_changes", R.string.differential_changes),
     PrivacyPolicy("privacy_policy", R.string.privacy_policy, false),
-    SettingsScreen("settings_screen", R.string.settings)
+    SettingsScreen("settings_screen", R.string.settings),
+    RecordListScreen("record_list", R.string.record_list),
 }

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/navigation/Screen.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/navigation/Screen.kt
@@ -39,5 +39,5 @@ enum class Screen(val route: String, val titleId: Int, val hasMenuItem: Boolean 
     DifferentialChanges("differential_changes", R.string.differential_changes),
     PrivacyPolicy("privacy_policy", R.string.privacy_policy, false),
     SettingsScreen("settings_screen", R.string.settings),
-    RecordListScreen("record_list", R.string.record_list),
+    RecordListScreen("record_list", R.string.record_list, false),
 }

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/exercisesessiondetail/ExerciseSessionDetailScreen.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/exercisesessiondetail/ExerciseSessionDetailScreen.kt
@@ -19,7 +19,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -29,23 +33,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.health.connect.client.records.ExerciseSessionRecord
-import androidx.health.connect.client.records.HeartRateRecord
-import androidx.health.connect.client.records.SpeedRecord
 import androidx.health.connect.client.units.Energy
 import androidx.health.connect.client.units.Length
-import androidx.health.connect.client.units.Velocity
 import com.example.healthconnectsample.R
 import com.example.healthconnectsample.data.ExerciseSessionData
 import com.example.healthconnectsample.data.formatTime
 import com.example.healthconnectsample.presentation.component.ExerciseSessionDetailsMinMaxAvg
-import com.example.healthconnectsample.presentation.component.heartRateSeries
 import com.example.healthconnectsample.presentation.component.sessionDetailsItem
-import com.example.healthconnectsample.presentation.component.speedSeries
+import com.example.healthconnectsample.presentation.screen.recordlist.RecordType
+import com.example.healthconnectsample.presentation.screen.recordlist.SeriesRecordsType
 import com.example.healthconnectsample.presentation.theme.HealthConnectTheme
 import java.time.Duration
-import java.time.ZonedDateTime
 import java.util.UUID
-import kotlin.random.Random
 
 /**
  * Shows a details of a given [ExerciseSessionRecord], including aggregates and underlying raw data.
@@ -56,6 +55,7 @@ fun ExerciseSessionDetailScreen(
     permissionsGranted: Boolean,
     sessionMetrics: ExerciseSessionData,
     uiState: ExerciseSessionDetailViewModel.UiState,
+    onDetailsClick: (String, String, String) -> Unit = { _, _, _ -> },
     onError: (Throwable?) -> Unit = {},
     onPermissionsResult: () -> Unit = {},
     onPermissionsLaunch: (Set<String>) -> Unit = {}
@@ -100,7 +100,7 @@ fun ExerciseSessionDetailScreen(
             } else {
                 sessionDetailsItem(labelId = R.string.total_active_duration) {
                     val activeDuration = sessionMetrics.totalActiveTime ?: Duration.ZERO
-                    Text(activeDuration.formatTime())
+                    Text(activeDuration.formatTime());
                 }
                 sessionDetailsItem(labelId = R.string.total_steps) {
                     Text(sessionMetrics.totalSteps?.toString() ?: "0")
@@ -111,10 +111,6 @@ fun ExerciseSessionDetailScreen(
                 sessionDetailsItem(labelId = R.string.total_energy) {
                     Text(sessionMetrics.totalEnergyBurned?.inCalories.toString())
                 }
-                speedSeries(
-                    labelId = R.string.speed_series,
-                    series = sessionMetrics.speedRecord
-                )
                 sessionDetailsItem(labelId = R.string.hr_stats) {
                     ExerciseSessionDetailsMinMaxAvg(
                         sessionMetrics.minHeartRate?.toString()
@@ -124,13 +120,28 @@ fun ExerciseSessionDetailScreen(
                         sessionMetrics.avgHeartRate?.toString()
                             ?: stringResource(id = R.string.not_available_abbrev)
                     )
+                    RecordsIconButton(sessionMetrics.uid, SeriesRecordsType.HEARTRATE, onDetailsClick)
                 }
-                heartRateSeries(
-                    labelId = R.string.hr_series,
-                    series = sessionMetrics.heartRateSeries
-                )
             }
         }
+    }
+}
+
+@Composable
+fun RecordsIconButton(uid: String, seriesRecordsType: SeriesRecordsType, onDetailsClick: (String, String, String) -> Unit = { _, _, _ -> }) {
+    IconButton(
+        onClick = {
+            onDetailsClick(
+                RecordType.EXERCISE_SESSION.toString(),
+                uid,
+                seriesRecordsType.toString()
+            )
+        },
+    ) {
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            stringResource(R.string.details_button)
+        )
     }
 }
 
@@ -141,17 +152,13 @@ fun ExerciseSessionScreenPreview() {
         val uid = UUID.randomUUID().toString()
         val sessionMetrics = ExerciseSessionData(
             uid = uid,
+            totalActiveTime = Duration.ofMinutes(75),
             totalSteps = 5152,
             totalDistance = Length.meters(11923.4),
             totalEnergyBurned = Energy.calories(1131.2),
             minHeartRate = 55,
             maxHeartRate = 103,
             avgHeartRate = 77,
-            heartRateSeries = generateHeartRateSeries(),
-            minSpeed = Velocity.metersPerSecond(2.5),
-            maxSpeed = Velocity.metersPerSecond(3.1),
-            avgSpeed = Velocity.metersPerSecond(2.8),
-            speedRecord = generateSpeedData(),
         )
 
         ExerciseSessionDetailScreen(
@@ -161,52 +168,4 @@ fun ExerciseSessionScreenPreview() {
             uiState = ExerciseSessionDetailViewModel.UiState.Done
         )
     }
-}
-
-private fun generateSpeedData(): List<SpeedRecord> {
-    val data = mutableListOf<SpeedRecord.Sample>()
-    val end = ZonedDateTime.now()
-    var time = ZonedDateTime.now()
-    for (index in 1..10) {
-        time = end.minusMinutes(index.toLong())
-        data.add(
-            SpeedRecord.Sample(
-                time = time.toInstant(),
-                speed = Velocity.metersPerSecond((Random.nextDouble(1.0, 5.0)))
-            )
-        )
-    }
-    return listOf(
-        SpeedRecord(
-            startTime = time.toInstant(),
-            startZoneOffset = time.offset,
-            endTime = end.toInstant(),
-            endZoneOffset = end.offset,
-            samples = data
-        )
-    )
-}
-
-private fun generateHeartRateSeries(): List<HeartRateRecord> {
-    val data = mutableListOf<HeartRateRecord.Sample>()
-    val end = ZonedDateTime.now()
-    var time = ZonedDateTime.now()
-    for (index in 1..10) {
-        time = end.minusMinutes(index.toLong())
-        data.add(
-            HeartRateRecord.Sample(
-                time = time.toInstant(),
-                beatsPerMinute = Random.nextLong(55, 180)
-            )
-        )
-    }
-    return listOf(
-        HeartRateRecord(
-            startTime = time.toInstant(),
-            startZoneOffset = time.offset,
-            endTime = end.toInstant(),
-            endZoneOffset = end.offset,
-            samples = data
-        )
-    )
 }

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/exercisesessiondetail/ExerciseSessionDetailScreen.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/exercisesessiondetail/ExerciseSessionDetailScreen.kt
@@ -16,11 +16,13 @@
 package com.example.healthconnectsample.presentation.screen.exercisesessiondetail
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -98,18 +100,35 @@ fun ExerciseSessionDetailScreen(
                     }
                 }
             } else {
+                item {
+                    Text(
+                        text = stringResource(id = R.string.exercise_session_detail),
+                        style = MaterialTheme.typography.h5,
+                        color = MaterialTheme.colors.primary,
+                    )
+                    Text("id: " + sessionMetrics.uid)
+                }
                 sessionDetailsItem(labelId = R.string.total_active_duration) {
-                    val activeDuration = sessionMetrics.totalActiveTime ?: Duration.ZERO
-                    Text(activeDuration.formatTime());
+                        val activeDuration = sessionMetrics.totalActiveTime ?: Duration.ZERO
+                        Text(activeDuration.formatTime());
                 }
                 sessionDetailsItem(labelId = R.string.total_steps) {
-                    Text(sessionMetrics.totalSteps?.toString() ?: "0")
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(sessionMetrics.totalSteps?.toString() ?: "0")
+                        RecordsIconButton(sessionMetrics.uid, SeriesRecordsType.STEPS, onDetailsClick)
+                    }
                 }
                 sessionDetailsItem(labelId = R.string.total_distance) {
-                    Text(sessionMetrics.totalDistance?.toString() ?: "0.0")
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(sessionMetrics.totalDistance?.toString() ?: "0.0")
+                        RecordsIconButton(sessionMetrics.uid, SeriesRecordsType.DISTANCE, onDetailsClick)
+                    }
                 }
                 sessionDetailsItem(labelId = R.string.total_energy) {
-                    Text(sessionMetrics.totalEnergyBurned?.inCalories.toString())
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(sessionMetrics.totalEnergyBurned?.inCalories.toString())
+                        RecordsIconButton(sessionMetrics.uid, SeriesRecordsType.CALORIES, onDetailsClick)
+                    }
                 }
                 sessionDetailsItem(labelId = R.string.hr_stats) {
                     ExerciseSessionDetailsMinMaxAvg(

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/recordlist/RecordListScreen.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/recordlist/RecordListScreen.kt
@@ -17,18 +17,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.Record
-import androidx.health.connect.client.records.SpeedRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
 import androidx.health.connect.client.records.metadata.Metadata
-import androidx.health.connect.client.units.Velocity
 import com.example.healthconnectsample.R
 import com.example.healthconnectsample.formatDisplayTimeStartEnd
 import com.example.healthconnectsample.presentation.theme.HealthConnectTheme
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.time.ZonedDateTime.now
-import java.time.temporal.ChronoUnit
 import java.util.UUID
 import kotlin.random.Random
 

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/recordlist/RecordListScreen.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/recordlist/RecordListScreen.kt
@@ -1,10 +1,12 @@
 package com.example.healthconnectsample.presentation.screen.recordlist
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -14,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.Record
@@ -63,57 +66,73 @@ fun RecordListScreen(
     }
 
     if (uiState != RecordListScreenViewModel.UiState.Uninitialized) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.Top,
-            /*horizontalAlignment = Alignment.CenterHorizontally*/ ) {
-            if (!permissionsGranted) {
-                item {
-                    Button(onClick = { onPermissionsLaunch(permissions) }) {
-                        Text(text = stringResource(R.string.permissions_button_label))
-                    }
-                }
-            } else {
-                item {
-                    Text(
-                        text = "${recordType.clazz.simpleName} [$uid]",
-                        overflow = TextOverflow.Ellipsis,
-                        maxLines = 1)
-                }
-                item {
-                    Text(
-                        text = "${seriesRecordsType.clazz.simpleName} list",
-                    )
-                }
-                when (seriesRecordsType) {
-                    SeriesRecordsType.STEPS -> {
-                        for (record in recordList.map { it as StepsRecord }) {
-                            renderData(record, record.startTime, record.endTime) {
-                                Text(text = "count: " + record.count)
-                            }
+        HealthConnectTheme {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 5.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                if (!permissionsGranted) {
+                    item {
+                        Button(onClick = { onPermissionsLaunch(permissions) }) {
+                            Text(text = stringResource(R.string.permissions_button_label))
                         }
                     }
-                    SeriesRecordsType.DISTANCE -> {
-                        for (record in recordList.map { it as DistanceRecord }) {
-                            renderData(record, record.startTime, record.endTime) {
-                                Text(text = "count: " + record.distance + " m")
+                } else {
+                    item {
+                        Text(
+                            text = "${recordType.clazz.simpleName}",
+                            style = MaterialTheme.typography.h6,
+                            color = MaterialTheme.colors.primary,
+                            overflow = TextOverflow.Ellipsis,
+                            maxLines = 1
+                        )
+                        Text(
+                            text = uid,
+                            style = MaterialTheme.typography.body2,
+                            color = MaterialTheme.colors.primary
+                        )
+                    }
+                    item {
+                        Text(
+                            text = "${seriesRecordsType.clazz.simpleName} list",
+                            style = MaterialTheme.typography.h6,
+                            color = MaterialTheme.colors.primary
+                        )
+                    }
+                    when (seriesRecordsType) {
+                        SeriesRecordsType.STEPS -> {
+                            for (record in recordList.map { it as StepsRecord }) {
+                                renderData(record, record.startTime, record.endTime,
+                                    "Count: " + record.count
+                                )
                             }
                         }
-                    }
-                    SeriesRecordsType.CALORIES -> {
-                        for (record in recordList.map { it as TotalCaloriesBurnedRecord }) {
-                            renderData(record, record.startTime, record.endTime) {
-                                Text(text = "Energy: " + record.energy)
+
+                        SeriesRecordsType.DISTANCE -> {
+                            for (record in recordList.map { it as DistanceRecord }) {
+                                renderData(record, record.startTime, record.endTime,
+                                    "Count: " + record.distance
+                                )
                             }
                         }
-                    }
-                    SeriesRecordsType.HEARTRATE -> {
-                        for (record in recordList.map { it as HeartRateRecord }) {
-                            renderData(record, record.startTime, record.endTime) {
-                                Text(
-                                    text =
+
+                        SeriesRecordsType.CALORIES -> {
+                            for (record in recordList.map { it as TotalCaloriesBurnedRecord }) {
+                                renderData(record, record.startTime, record.endTime,
+                                    "Energy: " + record.energy
+                                )
+                            }
+                        }
+
+                        SeriesRecordsType.HEARTRATE -> {
+                            for (record in recordList.map { it as HeartRateRecord }) {
+                                renderData(record, record.startTime, record.endTime,
                                     "Heartbeat Samples: " +
-                                            record.samples.map { it.beatsPerMinute }.joinToString(", "))
+                                            record.samples.map { it.beatsPerMinute }
+                                                .joinToString(", ")
+
+                                )
                             }
                         }
                     }
@@ -136,12 +155,16 @@ fun LazyListScope.renderData(
     record: Record,
     startTime: Instant,
     endTime: Instant,
-    content: @Composable () -> Unit
+    data: String
 ) {
     item {
-        Text(text = "id: " + record.metadata.id)
-        Text(text = formatDisplayTimeStartEnd(startTime, null, endTime, null))
-        content()
+        Text(text = record.metadata.id,
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.primary)
+        Text(text = formatDisplayTimeStartEnd(startTime, null, endTime, null),
+            style = MaterialTheme.typography.body2)
+        Text(text = data,
+            style = MaterialTheme.typography.body2)
     }
 }
 

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/recordlist/RecordListScreen.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/recordlist/RecordListScreen.kt
@@ -1,0 +1,169 @@
+package com.example.healthconnectsample.presentation.screen.recordlist
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.health.connect.client.records.DistanceRecord
+import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.SpeedRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
+import androidx.health.connect.client.records.metadata.Metadata
+import androidx.health.connect.client.units.Velocity
+import com.example.healthconnectsample.R
+import com.example.healthconnectsample.formatDisplayTimeStartEnd
+import com.example.healthconnectsample.presentation.theme.HealthConnectTheme
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.ZonedDateTime.now
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import kotlin.random.Random
+
+@Composable
+fun RecordListScreen(
+    uid: String,
+    permissions: Set<String>,
+    permissionsGranted: Boolean,
+    recordType: RecordType,
+    seriesRecordsType: SeriesRecordsType,
+    recordList: List<Record>,
+    uiState: RecordListScreenViewModel.UiState,
+    onError: (Throwable?) -> Unit = {},
+    onPermissionsResult: () -> Unit = {},
+    onPermissionsLaunch: (Set<String>) -> Unit = {}
+) {
+    // Remember the last error ID, such that it is possible to avoid re-launching the error
+    // notification for the same error when the screen is recomposed, or configuration changes etc.
+    val errorId = rememberSaveable { mutableStateOf(UUID.randomUUID()) }
+
+    LaunchedEffect(uiState) {
+        // If the initial data load has not taken place, attempt to load the data.
+        if (uiState is RecordListScreenViewModel.UiState.Uninitialized) {
+            onPermissionsResult()
+        }
+
+        // The [RecordListScreenViewModel.UiState] provides details of whether the last action
+        // was a success or resulted in an error. Where an error occurred, for example in reading
+        // and writing to Health Connect, the user is notified, and where the error is one that can
+        // be recovered from, an attempt to do so is made.
+        if (uiState is RecordListScreenViewModel.UiState.Error && errorId.value != uiState.uuid) {
+            onError(uiState.exception)
+            errorId.value = uiState.uuid
+        }
+    }
+
+    if (uiState != RecordListScreenViewModel.UiState.Uninitialized) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Top,
+            /*horizontalAlignment = Alignment.CenterHorizontally*/ ) {
+            if (!permissionsGranted) {
+                item {
+                    Button(onClick = { onPermissionsLaunch(permissions) }) {
+                        Text(text = stringResource(R.string.permissions_button_label))
+                    }
+                }
+            } else {
+                item {
+                    Text(
+                        text = "${recordType.clazz.simpleName} [$uid]",
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1)
+                }
+                item {
+                    Text(
+                        text = "${seriesRecordsType.clazz.simpleName} list",
+                    )
+                }
+                when (seriesRecordsType) {
+                    SeriesRecordsType.STEPS -> {
+                        for (record in recordList.map { it as StepsRecord }) {
+                            renderData(record, record.startTime, record.endTime) {
+                                Text(text = "count: " + record.count)
+                            }
+                        }
+                    }
+                    SeriesRecordsType.DISTANCE -> {
+                        for (record in recordList.map { it as DistanceRecord }) {
+                            renderData(record, record.startTime, record.endTime) {
+                                Text(text = "count: " + record.distance + " m")
+                            }
+                        }
+                    }
+                    SeriesRecordsType.CALORIES -> {
+                        for (record in recordList.map { it as TotalCaloriesBurnedRecord }) {
+                            renderData(record, record.startTime, record.endTime) {
+                                Text(text = "Energy: " + record.energy)
+                            }
+                        }
+                    }
+                    SeriesRecordsType.HEARTRATE -> {
+                        for (record in recordList.map { it as HeartRateRecord }) {
+                            renderData(record, record.startTime, record.endTime) {
+                                Text(
+                                    text =
+                                    "Heartbeat Samples: " +
+                                            record.samples.map { it.beatsPerMinute }.joinToString(", "))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun buildStepsSeries(sessionStartTime: ZonedDateTime, sessionEndTime: ZonedDateTime) =
+    StepsRecord(
+        startTime = sessionStartTime.toInstant(),
+        startZoneOffset = sessionStartTime.offset,
+        endTime = sessionEndTime.toInstant(),
+        endZoneOffset = sessionEndTime.offset,
+        count = Random.nextInt(9000).toLong() + 1000,
+        metadata = Metadata(id = UUID.randomUUID().toString()))
+
+fun LazyListScope.renderData(
+    record: Record,
+    startTime: Instant,
+    endTime: Instant,
+    content: @Composable () -> Unit
+) {
+    item {
+        Text(text = "id: " + record.metadata.id)
+        Text(text = formatDisplayTimeStartEnd(startTime, null, endTime, null))
+        content()
+    }
+}
+
+@Preview
+@Composable
+fun RecordListScreenPreview() {
+    HealthConnectTheme {
+        val uid = UUID.randomUUID().toString()
+        RecordListScreen(
+            uid = uid,
+            permissions = setOf(),
+            permissionsGranted = true,
+            recordType = RecordType.EXERCISE_SESSION,
+            seriesRecordsType = SeriesRecordsType.STEPS,
+            recordList =
+            listOf(
+                buildStepsSeries(now().minusMinutes(180), now().minusMinutes(120)),
+                buildStepsSeries(now().minusMinutes(60), now())),
+            uiState = RecordListScreenViewModel.UiState.Done,
+        )
+    }
+}

--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/recordlist/RecordListScreenViewModel.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/recordlist/RecordListScreenViewModel.kt
@@ -1,0 +1,133 @@
+package com.example.healthconnectsample.presentation.screen.recordlist
+
+import android.os.RemoteException
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.DistanceRecord
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.healthconnectsample.data.HealthConnectManager
+import kotlinx.coroutines.launch
+import java.io.IOException
+import java.util.UUID
+import kotlin.reflect.KClass
+
+class RecordListScreenViewModel(
+    private val uid: String,
+    recordTypeString: String,
+    seriesRecordsTypeString: String,
+    private val healthConnectManager: HealthConnectManager
+) : ViewModel() {
+    private val recordType: KClass<out Record> = RecordType.stringToClass(recordTypeString)
+    private val seriesRecordsType: KClass<out Record> = SeriesRecordsType.stringToClass(seriesRecordsTypeString)
+    val permissions = setOf(HealthPermission.getReadPermission(recordType))
+
+    var permissionsGranted = mutableStateOf(false)
+        private set
+
+    var recordList = mutableStateListOf<Record>()
+        private set
+
+    var uiState: UiState by mutableStateOf(UiState.Uninitialized)
+        private set
+
+    val permissionsLauncher = healthConnectManager.requestPermissionsActivityContract()
+
+    fun initialLoad() {
+        viewModelScope.launch {
+            tryWithPermissionsCheck {
+                recordList.clear()
+                recordList.addAll(healthConnectManager.fetchSeriesRecordsFromUid(recordType, uid, seriesRecordsType))
+            }
+        }
+    }
+
+    /**
+     * Provides permission check and error handling for Health Connect suspend function calls.
+     *
+     * Permissions are checked prior to execution of [block], and if all permissions aren't granted
+     * the [block] won't be executed, and [permissionsGranted] will be set to false, which will result
+     * in the UI showing the permissions button.
+     *
+     * Where an error is caught, of the type Health Connect is known to throw, [uiState] is set to
+     * [UiState.Error], which results in the snackbar being used to show the error message.
+     */
+    private suspend fun tryWithPermissionsCheck(block: suspend () -> Unit) {
+        permissionsGranted.value = healthConnectManager.hasAllPermissions(permissions)
+        uiState =
+            try {
+                if (permissionsGranted.value) {
+                    block()
+                }
+                UiState.Done
+            } catch (remoteException: RemoteException) {
+                UiState.Error(remoteException)
+            } catch (securityException: SecurityException) {
+                UiState.Error(securityException)
+            } catch (ioException: IOException) {
+                UiState.Error(ioException)
+            } catch (illegalStateException: IllegalStateException) {
+                UiState.Error(illegalStateException)
+            }
+    }
+
+    sealed class UiState {
+        object Uninitialized : UiState()
+
+        object Done : UiState()
+
+        // A random UUID is used in each Error object to allow errors to be uniquely identified,
+        // and recomposition won't result in multiple snackbars.
+        data class Error(val exception: Throwable, val uuid: UUID = UUID.randomUUID()) : UiState()
+    }
+}
+
+class RecordListViewModelFactory(
+    private val uid: String,
+    private val recordTypeString: String,
+    private val seriesRecordsTypeString: String,
+    private val healthConnectManager: HealthConnectManager
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(RecordListScreenViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return RecordListScreenViewModel(
+                uid = uid,
+                recordTypeString = recordTypeString,
+                seriesRecordsTypeString = seriesRecordsTypeString,
+                healthConnectManager = healthConnectManager)
+                    as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+
+enum class RecordType(val clazz: KClass<out Record>) {
+    EXERCISE_SESSION(ExerciseSessionRecord::class),
+    SLEEP_SESSION(SleepSessionRecord::class);
+
+    companion object {
+        fun stringToClass(recordTypeString: String) = RecordType.valueOf(recordTypeString).clazz
+    }
+}
+
+enum class SeriesRecordsType(val clazz: KClass<out Record>) {
+    STEPS(StepsRecord::class),
+    DISTANCE(DistanceRecord::class),
+    CALORIES(TotalCaloriesBurnedRecord::class),
+    HEARTRATE(HeartRateRecord::class);
+
+    companion object {
+        fun stringToClass(seriesRecordsTypeString: String) = SeriesRecordsType.valueOf(seriesRecordsTypeString).clazz
+    }
+}

--- a/health-connect/HealthConnectSample/app/src/main/res/values/strings.xml
+++ b/health-connect/HealthConnectSample/app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_title">[No title]</string>
     <string name="unknown_app">[Unknown app]</string>
     <string name="delete_button">Delete</string>
+    <string name="details_button">Details</string>
 
     <!-- Exercise Session detail screen -->
     <string name="total_active_duration">Total active duration</string>
@@ -127,6 +128,11 @@
     <string name="differential_changes_type_sleep_stage">Sleep stage</string>
     <string name="differential_changes_type_distance">Distance</string>
     <string name="differential_changes_type_weight">Weight</string>
+
+    <!-- Record List screen -->
+    <string name="record_list">Record list</string>
+    <string name="exercise_sessions_record_list">Exercise Sessions Record list</string>
+    <string name="sleep_sessions_record_list">Sleep Sessions Record list</string>
 
     <!-- Health Connect settings -->
     <string name="settings">Settings</string>


### PR DESCRIPTION
Remove series records from Exercise detail screen and add an arrow icon that points to a new Records screen. This new Records screen is intended to be a general series Records page and will perform 2 queries, 1 with the original uid of the record and 1 for the series records using the time range of the former. Information about record types will be passed via enum string values (due to Navigation parameters generally being limited to primitives & Strings) with a limited initial set of supported Record types.