### PR TITLE
Fix Variable Name activity to context

### DIFF
--- a/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/SettingsScreen.kt
+++ b/health-connect/HealthConnectSample/app/src/main/java/com/example/healthconnectsample/presentation/screen/SettingsScreen.kt
@@ -38,8 +38,8 @@ import com.example.healthconnectsample.R
 @Composable
 fun SettingsScreen(
     revokeAllPermissions: () -> Unit
-){
-    val activity = LocalContext.current
+) {
+    val context = LocalContext.current
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -51,7 +51,7 @@ fun SettingsScreen(
             val settingsIntent = Intent()
             settingsIntent.action =
                 HealthConnectClient.ACTION_HEALTH_CONNECT_SETTINGS
-            activity.startActivity(settingsIntent) }
+            context.startActivity(settingsIntent) }
         ) {
             Text(text = stringResource(id = R.string.manage))
         }
@@ -59,7 +59,6 @@ fun SettingsScreen(
             revokeAllPermissions() }
         ) {
             Text(text = stringResource(id = R.string.disconnect))
-            
         }
     }
 


### PR DESCRIPTION
## Summary of Changes

Replaced activity with context when retrieving the current context using LocalContext.current.
Updated the variable name from activity to context for clarity and consistency, as LocalContext.current returns a context rather than an activity.
This change improves code readability and aligns the variable name with its intended use.
## Details

The previous code used activity to represent the context, which could lead to misunderstandings since LocalContext.current provides a Context object, not specifically an Activity.
The updated code now correctly refers to the context as context, enhancing code clarity and avoiding potential confusion for developers reading or maintaining the code.