### PR TITLE
Add triggers to .github/workflows/

### DIFF
--- a/.github/workflows/ExerciseSampleCompose.yml
+++ b/.github/workflows/ExerciseSampleCompose.yml
@@ -1,6 +1,7 @@
 name: ExerciseSampleCompose
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -18,7 +19,7 @@ env:
 jobs:
   build:
     # Skip build if head commit contains 'skip ci'
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/HealthConnectSample.yml
+++ b/.github/workflows/HealthConnectSample.yml
@@ -1,6 +1,7 @@
 name: HealthConnectSample
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -18,7 +19,7 @@ env:
 jobs:
   build:
     # Skip build if head commit contains 'skip ci'
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/HealthPlatformSample.yml
+++ b/.github/workflows/HealthPlatformSample.yml
@@ -1,6 +1,7 @@
 name: HealthPlatformSample
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -18,7 +19,7 @@ env:
 jobs:
   build:
     # Skip build if head commit contains 'skip ci'
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/MeasureDataCompose.yml
+++ b/.github/workflows/MeasureDataCompose.yml
@@ -1,6 +1,7 @@
 name: MeasureDataCompose
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -18,7 +19,7 @@ env:
 jobs:
   build:
     # Skip build if head commit contains 'skip ci'
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/PassiveDataCompose.yml
+++ b/.github/workflows/PassiveDataCompose.yml
@@ -1,6 +1,7 @@
 name: PassiveDataCompose
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -18,7 +19,7 @@ env:
 jobs:
   build:
     # Skip build if head commit contains 'skip ci'
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/PassiveGoalsCompose.yml
+++ b/.github/workflows/PassiveGoalsCompose.yml
@@ -1,6 +1,7 @@
 name: PassiveGoalsCompose
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -18,7 +19,7 @@ env:
 jobs:
   build:
     # Skip build if head commit contains 'skip ci'
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 40


### PR DESCRIPTION
This PR standardizes GitHub Actions triggers in workflow files within `.github/workflows/`.

The goal is to ensure workflows run consistently on `push`, `pull_request`, and `workflow_dispatch` events where appropriate.

This is part of a batch of pull requests across repositories owned by the `android` organization on GitHub.

**Project Owner:** Please review the changes carefully to ensure they are correct and appropriate for this project before approving and merging.

* If you do not think this change is appropriate (e.g., a workflow should NOT run on one of these triggers), please leave a comment explaining why.
* If you think the goal is appropriate but notice a mistake in the implementation, please leave a comment detailing the mistake.
