### PR TITLE
Add build workflows for samples

### DIFF
--- a/.github/workflows/build-exercise-sample-compose.yml
+++ b/.github/workflows/build-exercise-sample-compose.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Exercise Sample Compose
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: health-services/ExerciseSampleCompose
+
+      - name: Build ExerciseSampleCompose app
+        working-directory: health-services/ExerciseSampleCompose
+        run: ./gradlew app:assembleDebug

--- a/.github/workflows/build-health-connect-sample.yml
+++ b/.github/workflows/build-health-connect-sample.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Health Connect Sample
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: health-connect/HealthConnectSample
+
+      - name: Build HealthConnectSample app
+        working-directory: health-connect/HealthConnectSample
+        run: ./gradlew app:assembleDebug

--- a/.github/workflows/build-health-platform-sample.yml
+++ b/.github/workflows/build-health-platform-sample.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Health Platform Sample
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: health-platform-v1/HealthPlatformSample
+
+      - name: Build HealthPlatformSample app
+        working-directory: health-platform-v1/HealthPlatformSample
+        run: ./gradlew app:assembleDebug


### PR DESCRIPTION
This commit adds build workflows for the following samples:

- Exercise Sample Compose
- Health Connect Sample
- Health Platform Sample

These workflows are triggered on push, pull request, and workflow_dispatch events, and they build the debug version of the respective app.