### PR TITLE
Update ExerciseScreen to work better in ambient mode

### DIFF
--- a/health-services/ExerciseSampleCompose/app/build.gradle
+++ b/health-services/ExerciseSampleCompose/app/build.gradle
@@ -22,12 +22,12 @@ plugins {
 }
 
 android {
-  compileSdk 35
+  compileSdk 36
 
   defaultConfig {
     applicationId "com.example.exercisecompose"
     minSdk 30
-    targetSdk 34
+    targetSdk 36
     versionCode 1
     versionName "1.0"
   }

--- a/health-services/ExerciseSampleCompose/app/src/main/AndroidManifest.xml
+++ b/health-services/ExerciseSampleCompose/app/src/main/AndroidManifest.xml
@@ -16,12 +16,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- For receiving exercise metrics. -->
-    <uses-permission android:name="android.permission.BODY_SENSORS" />
+    <uses-permission android:name="android.permission.BODY_SENSORS" android:maxSdkVersion="35" />
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/app/MainActivity.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/app/MainActivity.kt
@@ -17,6 +17,7 @@ package com.example.exercisesamplecompose.app
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.runtime.LaunchedEffect
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -25,14 +26,26 @@ import androidx.navigation.NavHostController
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.example.exercisesamplecompose.presentation.ExerciseSampleApp
 import com.example.exercisesamplecompose.presentation.exercise.ExerciseViewModel
+import com.example.exercisesamplecompose.presentation.preparing.PreparingViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : FragmentActivity() {
 
     private lateinit var navController: NavHostController
-
     private val exerciseViewModel by viewModels<ExerciseViewModel>()
+    private val preparingViewModel by viewModels<PreparingViewModel>()
+
+    // Register the permissions callback
+    private val requestPermissions = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val allGranted = permissions.values.all { it }
+        if (allGranted) {
+            // All permissions granted, proceed with exercise
+            exerciseViewModel.startExercise()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splash = installSplashScreen()
@@ -41,6 +54,9 @@ class MainActivity : FragmentActivity() {
         splash.setKeepOnScreenCondition { pendingNavigation }
 
         super.onCreate(savedInstanceState)
+
+        // Request permissions when activity is created
+        requestPermissions.launch(PreparingViewModel.permissions.toTypedArray())
 
         setContent {
             navController = rememberSwipeDismissableNavController()

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/component/FormattingUtils.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/component/FormattingUtils.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.wear.compose.material.MaterialTheme
+import com.google.android.horologist.compose.ambient.LocalAmbientState
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import kotlin.math.roundToInt
@@ -48,7 +49,7 @@ fun formatElapsedTime(
         }
         if (includeSeconds) {
             val seconds = elapsedDuration.seconds % SECONDS_PER_MINUTE
-            append("%02d".format(seconds))
+            if (LocalAmbientState.current.isInteractive) append("%02d".format(seconds)) else append("--")
             withStyle(style = MaterialTheme.typography.caption3.toSpanStyle()) {
                 append("s")
             }

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/component/HRText.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/component/HRText.kt
@@ -15,7 +15,6 @@
  */
 package com.example.exercisesamplecompose.presentation.component
 
-import android.R.attr.fontWeight
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/component/HRText.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/component/HRText.kt
@@ -15,6 +15,7 @@
  */
 package com.example.exercisesamplecompose.presentation.component
 
+import android.R.attr.fontWeight
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,6 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
+import com.google.android.horologist.compose.ambient.LocalAmbientState
 
 @Composable
 fun HRText(hr: Double?) {
@@ -36,7 +38,7 @@ fun HRText(hr: Double?) {
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()) {
             Text(
-                text = "${hr ?: "--"}",
+                text = if (LocalAmbientState.current.isInteractive && hr != null) "$hr" else "--",
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colors.primary,
                 fontSize = 20.sp,

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/exercise/ExerciseScreen.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/exercise/ExerciseScreen.kt
@@ -92,7 +92,8 @@ fun ExerciseRoute(
                 onResumeClick = { viewModel.resumeExercise() },
                 onStartClick = { viewModel.startExercise() },
                 uiState = uiState,
-                modifier = modifier
+                modifier = modifier,
+                ambientState = AmbientState.Interactive
             )
         }
     }

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/exercise/ExerciseScreen.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/exercise/ExerciseScreen.kt
@@ -85,15 +85,15 @@ fun ExerciseRoute(
             onRestart = onRestart, onFinishActivity = onFinishActivity, uiState = uiState
         )
     } else {
-        AmbientAware {
+        AmbientAware { ambientState ->
             ExerciseScreen(
+                ambientState = ambientState,
                 onPauseClick = { viewModel.pauseExercise() },
                 onEndClick = { viewModel.endExercise() },
                 onResumeClick = { viewModel.resumeExercise() },
                 onStartClick = { viewModel.startExercise() },
                 uiState = uiState,
-                modifier = modifier,
-                ambientState = AmbientState.Interactive
+                modifier = modifier
             )
         }
     }

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/exercise/ExerciseScreen.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/exercise/ExerciseScreen.kt
@@ -135,39 +135,36 @@ fun ExerciseScreen(
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(initialPage = 1, pageCount = { 2 })
 
-    // Workaround bug in modifier placement in PagerScreen
-    Box {
-        PagerScreen(
-            state = pagerState,
-            modifier = modifier
-                .fillMaxSize()
-                .padding(6.dp)
-        ) { page ->
-            when (page) {
-                0 -> {
-                    ExerciseControlButtons(
-                        uiState = uiState,
-                        onStartClick = onStartClick,
-                        onEndClick = onEndClick,
-                        onResumeClick = {
-                            onResumeClick()
-                            coroutineScope.launch {
-                                pagerState.animateScrollToPage(1)
-                            }
+    PagerScreen(
+        state = pagerState,
+        modifier = modifier
+            .fillMaxSize()
+            .padding(6.dp)
+    ) { page ->
+        when (page) {
+            0 -> {
+                ExerciseControlButtons(
+                    uiState = uiState,
+                    onStartClick = onStartClick,
+                    onEndClick = onEndClick,
+                    onResumeClick = {
+                        onResumeClick()
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(1)
+                        }
 
-                        },
-                        onPauseClick = {
-                            onPauseClick()
-                            coroutineScope.launch {
-                                pagerState.animateScrollToPage(1)
-                            }
-                        },
-                    )
-                }
+                    },
+                    onPauseClick = {
+                        onPauseClick()
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(1)
+                        }
+                    },
+                )
+            }
 
-                1 -> {
-                    ExerciseMetrics(uiState = uiState)
-                }
+            1 -> {
+                ExerciseMetrics(uiState = uiState)
             }
         }
     }

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/exercise/ExerciseScreen.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/exercise/ExerciseScreen.kt
@@ -123,6 +123,7 @@ fun ErrorStartingExerciseScreen(
  */
 @Composable
 fun ExerciseScreen(
+    ambientState: AmbientState,
     onPauseClick: () -> Unit,
     onEndClick: () -> Unit,
     onResumeClick: () -> Unit,
@@ -309,7 +310,8 @@ fun ExerciseScreenPreview() {
                     ExerciseServiceState()
                 ),
                 exerciseState = ExerciseServiceState()
-            )
+            ),
+            ambientState = AmbientState.Interactive
         )
     }
 }

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/exercise/ExerciseScreen.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/exercise/ExerciseScreen.kt
@@ -85,9 +85,8 @@ fun ExerciseRoute(
             onRestart = onRestart, onFinishActivity = onFinishActivity, uiState = uiState
         )
     } else {
-        AmbientAware { ambientState ->
+        AmbientAware {
             ExerciseScreen(
-                ambientState = ambientState,
                 onPauseClick = { viewModel.pauseExercise() },
                 onEndClick = { viewModel.endExercise() },
                 onResumeClick = { viewModel.resumeExercise() },
@@ -124,7 +123,6 @@ fun ErrorStartingExerciseScreen(
  */
 @Composable
 fun ExerciseScreen(
-    ambientState: AmbientState,
     onPauseClick: () -> Unit,
     onEndClick: () -> Unit,
     onResumeClick: () -> Unit,
@@ -136,9 +134,7 @@ fun ExerciseScreen(
     val pagerState = rememberPagerState(initialPage = 1, pageCount = { 2 })
 
     // Workaround bug in modifier placement in PagerScreen
-    Box(
-        modifier = modifier.ambientBlank(ambientState)
-    ) {
+    Box {
         PagerScreen(
             state = pagerState,
             modifier = modifier
@@ -313,8 +309,7 @@ fun ExerciseScreenPreview() {
                     ExerciseServiceState()
                 ),
                 exerciseState = ExerciseServiceState()
-            ),
-            ambientState = AmbientState.Interactive,
+            )
         )
     }
 }

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/preparing/PreparingViewModel.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/preparing/PreparingViewModel.kt
@@ -64,16 +64,15 @@ class PreparingViewModel @Inject constructor(
     }
 
     companion object {
-        val permissions = mutableListOf(
-            Manifest.permission.BODY_SENSORS,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            Manifest.permission.ACTIVITY_RECOGNITION,
-        ).apply {
+        val permissions = buildList {
+            Manifest.permission.BODY_SENSORS
+            Manifest.permission.ACCESS_FINE_LOCATION
+            Manifest.permission.ACTIVITY_RECOGNITION
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
-                this.add(Manifest.permission.POST_NOTIFICATIONS)
+                add(Manifest.permission.POST_NOTIFICATIONS)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA)
-                this.add(HealthPermissions.READ_HEART_RATE)
-            this.toList()
+                add(HealthPermissions.READ_HEART_RATE)
         }
+
     }
 }

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/preparing/PreparingViewModel.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/preparing/PreparingViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.exercisesamplecompose.presentation.preparing
 
 import android.Manifest
+import android.health.connect.HealthPermissions
 import android.os.Build
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -70,7 +71,8 @@ class PreparingViewModel @Inject constructor(
         ).apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                 this.add(Manifest.permission.POST_NOTIFICATIONS)
-
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA)
+                this.add(HealthPermissions.READ_HEART_RATE)
             this.toList()
         }
     }

--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/preparing/PreparingViewModel.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/preparing/PreparingViewModel.kt
@@ -65,14 +65,13 @@ class PreparingViewModel @Inject constructor(
 
     companion object {
         val permissions = buildList {
-            Manifest.permission.BODY_SENSORS
-            Manifest.permission.ACCESS_FINE_LOCATION
-            Manifest.permission.ACTIVITY_RECOGNITION
+            add(Manifest.permission.BODY_SENSORS)
+            add(Manifest.permission.ACCESS_FINE_LOCATION)
+            add(Manifest.permission.ACTIVITY_RECOGNITION)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                 add(Manifest.permission.POST_NOTIFICATIONS)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA)
                 add(HealthPermissions.READ_HEART_RATE)
         }
-
     }
 }

--- a/health-services/ExerciseSampleCompose/app/src/test/java/com/example/exercisesamplecompose/presentation/ExerciseScreenTest.kt
+++ b/health-services/ExerciseSampleCompose/app/src/test/java/com/example/exercisesamplecompose/presentation/ExerciseScreenTest.kt
@@ -47,6 +47,7 @@ class ExerciseScreenTest(override val device: WearDevice) : WearDeviceScreenshot
         AppScaffold(
             timeText = { ResponsiveTimeText(timeSource = FixedTimeSource) }) {
             ExerciseScreen(
+                ambientState = AmbientState.Interactive,
                 onPauseClick = {},
                 onEndClick = {},
                 onResumeClick = {},
@@ -59,7 +60,6 @@ class ExerciseScreenTest(override val device: WearDevice) : WearDeviceScreenshot
                     ),
                     exerciseState = ExerciseServiceState()
                 ),
-                ambientState = AmbientState.Interactive,
             )
         }
     }


### PR DESCRIPTION
Previously, we blanked out most of the screen:

![adb-screenshot-20250508223358](https://github.com/user-attachments/assets/3964f0d5-706d-45dd-977d-59b6d93896c4)

Now, we display a simplified metrics screen, with "--" replacing the values that are usually frequently updated:

![adb-screenshot-20250508222916](https://github.com/user-attachments/assets/e2e2f13e-8edf-40c5-89a7-d314c0b6c441)
