### PR TITLE
Align BODY_SENSORS permission request with API 36 migration guidelines

### DIFF
--- a/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/preparing/PreparingViewModel.kt
+++ b/health-services/ExerciseSampleCompose/app/src/main/java/com/example/exercisesamplecompose/presentation/preparing/PreparingViewModel.kt
@@ -84,7 +84,9 @@ constructor(
 
     companion object {
         val permissions = buildList {
-            add(Manifest.permission.BODY_SENSORS)
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                add(Manifest.permission.BODY_SENSORS)
+            }
             add(Manifest.permission.ACCESS_FINE_LOCATION)
             add(Manifest.permission.ACTIVITY_RECOGNITION)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)


### PR DESCRIPTION
## Motivation
This PR updates the permission request logic to align with [Wear OS 6 (API level 36) migration guidelines](https://developer.android.com/health-and-fitness/health-services/permissions#migrate-support-api-36).

The `AndroidManifest.xml` correctly restricts the legacy `BODY_SENSORS` permission to `maxSdkVersion="35"`. However, the runtime permission array in `PreparingViewModel.kt` was requesting `BODY_SENSORS` on *all* API levels. 

While the Android system gracefully ignores invalid permission requests and still allows the exercise to proceed, requesting a permission that is explicitly restricted in the manifest is incorrect hygiene. It causes the `ActivityResultLauncher` to return a `false` result for that specific permission on API 36+, which could break future logic that strictly validates the success of the permission request array.

This PR updates `PreparingViewModel.kt` to only request `Manifest.permission.BODY_SENSORS` on API levels 35 and below, ensuring the runtime request matches the manifest declaration.

## How to test

### Verifying the fix

**On API 36+ (Android 16+):**
1. Run the `ExerciseSampleCompose` app on an Android 16 (API 36) emulator or device.
2. Tap the "Play" button to prepare an exercise.
3. Observe that the app correctly requests modern permissions (like `READ_HEART_RATE`) but no longer attempts to request the legacy `BODY_SENSORS` permission.
4. Grant all permissions and verify the exercise starts successfully.
*(Note: Ensure device-level Location is toggled ON in the system settings, otherwise the `DataType.LOCATION` request will fail).*

**On API <= 35 (Android 15 and below):**
1. Run the app on an Android 15 (API 35) or lower device/emulator.
2. Tap the "Play" button.
3. Verify that the legacy `BODY_SENSORS` permission is still requested as expected for backward compatibility.
4. Grant all permissions and verify the exercise starts successfully.